### PR TITLE
Autoload library pieces

### DIFF
--- a/lib/wellness.rb
+++ b/lib/wellness.rb
@@ -1,7 +1,7 @@
 module Wellness
-end
+  VERSION = '0.2.3'
 
-require 'wellness/version'
-require 'wellness/services/base'
-require 'wellness/system'
-require 'wellness/middleware'
+  autoload :Services,   'wellness/services'
+  autoload :Middleware, 'wellness/middleware'
+  autoload :System,     'wellness/system'
+end

--- a/lib/wellness.rb
+++ b/lib/wellness.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Wellness
   VERSION = '0.2.3'
 

--- a/lib/wellness/middleware.rb
+++ b/lib/wellness/middleware.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module Wellness
   # This is to be put into the Rack environment.
   #

--- a/lib/wellness/services.rb
+++ b/lib/wellness/services.rb
@@ -1,0 +1,8 @@
+module Wellness
+  module Services
+    autoload :Base,            'wellness/services/base'
+    autoload :PostgresService, 'wellness/services/postgres_service'
+    autoload :RedisService,    'wellness/services/redis_service'
+    autoload :SidekiqService,  'wellness/services/sidekiq_service'
+  end
+end

--- a/lib/wellness/services/base.rb
+++ b/lib/wellness/services/base.rb
@@ -2,27 +2,39 @@ module Wellness
   module Services
     # @author Matthew A. Johnston
     class Base
+
+      # Load dependencies when the class is loaded. This makes putting requires
+      # at the top of the file unnecessary. It plays nicely with the
+      # auto loader.
+      def self.dependency
+        yield if block_given?
+      end
+
+      # @param params [Hash]
       def initialize(params={})
         @params = params
         @health = false
       end
 
       # Flags the check as failed
+      # @return [FalseClass]
       def failed_check
         @health = false
       end
 
       # Flags the check as passed
+      # @return [TrueClass]
       def passed_check
         @health = true
       end
 
+      # @return [Hash]
       def params
         @params.dup
       end
 
       # Returns true if the service is healthy, otherwise false
-      # @return [Boolean]
+      # @return [TrueClass,FalseClass]
       def healthy?
         !!@health
       end

--- a/lib/wellness/services/postgres_service.rb
+++ b/lib/wellness/services/postgres_service.rb
@@ -1,10 +1,11 @@
-require 'pg'
-require 'wellness/services/base'
-
 module Wellness
   module Services
     # @author Matthew A. Johnston
-    class PostgresService < Wellness::Services::Base
+    class PostgresService < Base
+      dependency do
+        require('pg')
+      end
+
       def check
         case ping
         when PG::Constants::PQPING_NO_ATTEMPT

--- a/lib/wellness/services/redis_service.rb
+++ b/lib/wellness/services/redis_service.rb
@@ -1,9 +1,6 @@
-require 'redis'
-require 'wellness/services/base'
-
 module Wellness
   module Services
-    class RedisService < Wellness::Services::Base
+    class RedisService < Base
       KEYS = [
         'used_memory_human',
         'connected_clients',
@@ -20,6 +17,10 @@ module Wellness
         'uptime_in_seconds',
         'uptime_in_days'
       ]
+
+      dependency do
+        require('redis')
+      end
 
       def check
         client = Redis.new(self.params)

--- a/lib/wellness/services/redis_service.rb
+++ b/lib/wellness/services/redis_service.rb
@@ -23,7 +23,7 @@ module Wellness
       end
 
       def check
-        client = Redis.new(self.params)
+        client = build_client
         details = client.info.select { |k, _| KEYS.include?(k) }
 
         passed_check
@@ -39,6 +39,10 @@ module Wellness
             error: error.message
           }
         }
+      end
+
+      def build_client
+        Redis.new(self.params)
       end
     end
   end

--- a/lib/wellness/services/sidekiq_service.rb
+++ b/lib/wellness/services/sidekiq_service.rb
@@ -1,12 +1,13 @@
-require 'redis'
-require 'sidekiq'
-require 'wellness/services/base'
-
 module Wellness
   module Services
     # @author Matthew A. Johnston
-    class SidekiqService < Wellness::Services::Base
+    class SidekiqService < Base
       KEYS = %w(redis_stats uptime_in_days connected_clients used_memory_human used_memory_peak_human)
+
+      dependency do
+        require 'redis'
+        require 'sidekiq'
+      end
 
       def check
         sidekiq_stats = Sidekiq::Stats.new

--- a/lib/wellness/version.rb
+++ b/lib/wellness/version.rb
@@ -1,3 +1,0 @@
-module Wellness
-  VERSION = '0.2.2'
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  add_group('Services', 'wellness/services')
+end
 
 require 'rspec'
 require 'wellness'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'rspec'
 require 'wellness'
-

--- a/spec/wellness/services/base_spec.rb
+++ b/spec/wellness/services/base_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Wellness::Services::Base do
+  let(:params) { { test: 'data' } }
+  let(:service) { described_class.new(params) }
+  describe '#failed_check' do
+    before { service.passed_check }
+    subject { service.failed_check }
+    it 'returns false' do
+      expect(subject).to eq(false)
+    end
+    it 'flags the service as unhealthy' do
+      expect { subject }.to change(service, :healthy?).from(true).to(false)
+    end
+  end
+
+  describe '#passed_check' do
+    subject { service.passed_check }
+    it 'returns true' do
+      expect(subject).to eq(true)
+    end
+    it 'flags the service as healthy' do
+      expect { subject }.to change(service, :healthy?).from(false).to(true)
+    end
+  end
+
+  describe '#params' do
+    subject { service.params }
+    it 'returns the params that it was constructed with' do
+      expect(subject).to eq(params)
+    end
+  end
+
+  describe '#check' do
+    subject { service.check }
+    it 'returns an empty hash' do
+      expect(subject).to eq({})
+    end
+  end
+end

--- a/spec/wellness/services/postgres_service_spec.rb
+++ b/spec/wellness/services/postgres_service_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Wellness::Services::PostgresService do
+  pending
+end

--- a/spec/wellness/services/redis_service_spec.rb
+++ b/spec/wellness/services/redis_service_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Wellness::Services::RedisService do
+  let(:params) {
+    {
+      redis: {
+        url: 'redis://127.0.0.1:6379/0'
+      }
+    }
+  }
+  let(:service) { described_class.new(params) }
+  let(:redis_info) {
+    {
+      'uptime_in_seconds' => '612488',
+      'uptime_in_days' => '7',
+      'connected_clients' => '1',
+      'used_memory_human' => '979.22K',
+      'total_connections_received' => '2',
+      'total_commands_processed' => '1',
+      'rejected_connections' => '0',
+      'sync_full' => '0',
+      'sync_partial_ok' => '0',
+      'sync_partial_err' => '0',
+      'expired_keys' => '0',
+      'evicted_keys' => '0',
+      'keyspace_hits' => '0',
+      'keyspace_misses' => '0'
+    }
+  }
+  describe '#check' do
+    subject { service.check }
+    context 'when redis can\'t connect' do
+      it 'fails the health check' do
+        expect(subject).to include(status: 'UNHEALTHY')
+      end
+    end
+    context 'when redis returns the its details' do
+      let(:client) { double('Redis', info: redis_info) }
+      before do
+        service.stub(build_client: client)
+      end
+      it 'passes the health check' do
+        expect(subject).to include(status: 'HEALTHY')
+      end
+    end
+  end
+end

--- a/spec/wellness/services/sidekiq_service_spec.rb
+++ b/spec/wellness/services/sidekiq_service_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Wellness::Services::SidekiqService do
+  pending
+end

--- a/wellness.gemspec
+++ b/wellness.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'wellness/version'
+require 'wellness'
 
 Gem::Specification.new do |spec|
   spec.name          = 'wellness'
@@ -21,4 +21,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('bundler', '~> 1.3')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec')
+
+  # service dependencies
+  spec.add_development_dependency('pg')
+  spec.add_development_dependency('sidekiq')
+  spec.add_development_dependency('redis')
 end

--- a/wellness.gemspec
+++ b/wellness.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('bundler', '~> 1.3')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec')
+  spec.add_development_dependency('simplecov')
 
   # service dependencies
   spec.add_development_dependency('pg')


### PR DESCRIPTION
Added Wellness::Base.dependency to allow for libraries to be required at the time the class is loaded. It plays nicely with the autoloader.

Moved `VERSION` into `lib/wellness.rb` since the entire library is autoloaded.
