### PR TITLE
Refactored almost everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ necessarily have.
 
 ```rb
 # Within the configuration block
+
 system = Wellness::System.new('my-uber-duber-app')
-pg = Wellness::Services::PostgresService.new({
-  host: ENV['POSTGRESQL_HOST'],
-  port: ENV['POSTGRESQL_PORT'],
+system.use(Wellness::Services::PostgresService, 'database', {
+  host:     ENV['POSTGRESQL_HOST'],
+  port:     ENV['POSTGRESQL_PORT'],
   database: ENV['POSTGRESQL_DATABASE'],
-  user: ENV['POSTGRESQL_USERNAME'],
+  user:     ENV['POSTGRESQL_USERNAME'],
   password: ENV['POSTGRESQL_PASSWORD']
 })
-redis = Wellness::Services::RedisService.new({
+system.use(Wellness::Services::RedisService, 'redis', {
   host: ENV['REDIS_HOST']
 })
-system.add_service('database', pg)
-system.add_service('redis', redis)
+
 config.middleware.insert_before('::ActiveRecord::QueryCache', 'Wellness::Middleware', system)
 ```
 
@@ -38,18 +38,16 @@ config.middleware.insert_before('::ActiveRecord::QueryCache', 'Wellness::Middlew
 require 'wellness'
 
 system = Wellness::System.new('my-uber-duber-app')
-pg = Wellness::Services::PostgresService.new({
-  host: ENV['POSTGRESQL_HOST'],
-  port: ENV['POSTGRESQL_PORT'],
+system.use(Wellness::Services::PostgresService, 'database', {
+  host:     ENV['POSTGRESQL_HOST'],
+  port:     ENV['POSTGRESQL_PORT'],
   database: ENV['POSTGRESQL_DATABASE'],
-  user: ENV['POSTGRESQL_USERNAME'],
+  user:     ENV['POSTGRESQL_USERNAME'],
   password: ENV['POSTGRESQL_PASSWORD']
 })
-redis = Wellness::Services::RedisService.new({
+system.use(Wellness::Services::RedisService, 'redis', {
   host: ENV['REDIS_HOST']
 })
-system.add_service('database', pg)
-system.add_service('redis', redis)
 
 use(Wellness::Middleware, system)
 ```
@@ -107,12 +105,10 @@ run time. It can lead to unintended consequences, and weird bugs.
 class MyCustomService < Wellness::Services::Base
   def check
     if params[:foo]
-      passed_check
       {
         'status': 'HEALTHY'
       }
     else
-      failed_check
       {
         'status': 'UNHEALTHY'
       }
@@ -122,8 +118,7 @@ end
 
 # Initialize the wellness system
 system = Wellness::System.new('my-app')
-service = MyCustomService.new({foo: 'bar'})
-system.add_service('some service', service)
+system.use(MyCustomService, 'some service', {foo: 'bar'})
 
 # Load it into your rack
 use(Wellness::Middleware, system)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,28 @@ system.use(MyCustomService, 'some service', {foo: 'bar'})
 use(Wellness::Middleware, system)
 ```
 
+## Custom Details
+
+```ruby
+# Your custom detail component
+class MyDetail < Wellness::Detail
+  def check
+    {
+      'foo' => 12,
+      'bar' => 31,
+      'qux' => options[:qux]
+    }
+  end
+end
+
+# Initialize the wellness system
+system = Wellness::System.new('my-app')
+system.use(MyDetail, 'something', { qux: 9000 })
+
+# Load it into your rack
+use(Wellness::Middleware, system)
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/wellness.rb
+++ b/lib/wellness.rb
@@ -1,9 +1,12 @@
 require 'json'
 
 module Wellness
-  VERSION = '0.2.3'
+  VERSION = '1.0.0'
 
   autoload :Services,   'wellness/services'
   autoload :Middleware, 'wellness/middleware'
   autoload :System,     'wellness/system'
+  autoload :Detail,     'wellness/detail'
+  autoload :Report,     'wellness/report'
+  autoload :Factory,    'wellness/factory'
 end

--- a/lib/wellness/detail.rb
+++ b/lib/wellness/detail.rb
@@ -1,0 +1,17 @@
+module Wellness
+  # The parent class of all details that need to run.
+  #
+  # @author Matthew A. Johnston (warmwaffles)
+  class Detail
+    attr_reader :name
+
+    def initialize(name)
+      @name = name
+    end
+
+    # @return [Hash]
+    def call
+      {}
+    end
+  end
+end

--- a/lib/wellness/detail.rb
+++ b/lib/wellness/detail.rb
@@ -3,14 +3,20 @@ module Wellness
   #
   # @author Matthew A. Johnston (warmwaffles)
   class Detail
-    attr_reader :name
+    attr_reader :name, :result
 
     def initialize(name)
       @name = name
+      @result = {}
+    end
+
+    def call
+      @result = self.check
+      self
     end
 
     # @return [Hash]
-    def call
+    def check
       {}
     end
   end

--- a/lib/wellness/detail.rb
+++ b/lib/wellness/detail.rb
@@ -3,10 +3,11 @@ module Wellness
   #
   # @author Matthew A. Johnston (warmwaffles)
   class Detail
-    attr_reader :name, :result
+    attr_reader :name, :options, :result
 
-    def initialize(name)
+    def initialize(name, options={})
       @name = name
+      @options = options
       @result = {}
     end
 

--- a/lib/wellness/factory.rb
+++ b/lib/wellness/factory.rb
@@ -1,0 +1,14 @@
+module Wellness
+  # A simple class that builds the provided class with the provided arguments
+  # @author Matthew A. Johnston (warmwaffles)
+  class Factory
+    def initialize(klass, *args)
+      @klass = klass
+      @args  = args
+    end
+
+    def build
+      @klass.new(*@args)
+    end
+  end
+end

--- a/lib/wellness/middleware.rb
+++ b/lib/wellness/middleware.rb
@@ -6,38 +6,25 @@ module Wellness
     def initialize(app, system, options={})
       @app = app
       @system = system
+      @options = options
+    end
 
-      # Optional arguments
-      @health_status_path = options[:status_path] || '/health/status'
-      @health_details_path = options[:details_path] || '/health/details'
+    def health_status_path
+      @options[:status_path] || '/health/status'
+    end
+
+    def health_details_path
+      @options[:details_path] || '/health/details'
     end
 
     def call(env)
       case env['PATH_INFO']
-      when @health_status_path
-        health_status_check
-      when @health_details_path
-        health_details_check
+      when health_status_path
+        @system.simple_check
+      when health_details_path
+        @system.detailed_check
       else
         @app.call(env)
-      end
-    end
-
-    private
-
-    def health_status_check
-      if @system.check
-        [200, { 'Content-Type' => 'application/json' }, [{ status: 'HEALTHY' }.to_json]]
-      else
-        [500, { 'Content-Type' => 'application/json' }, [{ status: 'UNHEALTHY' }.to_json]]
-      end
-    end
-
-    def health_details_check
-      if @system.check
-        [200, { 'Content-Type' => 'application/json' }, [@system.to_json]]
-      else
-        [500, { 'Content-Type' => 'application/json' }, [@system.to_json]]
       end
     end
   end

--- a/lib/wellness/report.rb
+++ b/lib/wellness/report.rb
@@ -1,13 +1,11 @@
 module Wellness
   # A simple presenter for the services and details of the Wellness System.
-  # This does not contain any logic for running checks and gathering details,
-  # simply because the details and results should be passed in.
   #
   # @author Matthew A. Johnston (warmwaffles)
   class Report
     # @param services [Hash]
     # @param details [Hash]
-    def initialize(services={}, details={})
+    def initialize(services, details)
       @services = services
       @details = details
     end
@@ -16,8 +14,8 @@ module Wellness
     def detailed
       {
         status: status,
-        services: @services,
-        details: @details
+        services: services,
+        details: details
       }
     end
 
@@ -47,7 +45,15 @@ module Wellness
 
     # @return [TrueClass,FalseClass]
     def healthy?
-      @services.values.all? { |h| h[:status] == 'HEALTHY' }
+      @services.all?(&:healthy?)
+    end
+
+    def services
+      Hash[@services.map { |s| [s.name, s.result] }]
+    end
+
+    def details
+      Hash[@details.map { |d| [d.name, d.result] }]
     end
   end
 end

--- a/lib/wellness/report.rb
+++ b/lib/wellness/report.rb
@@ -1,0 +1,53 @@
+module Wellness
+  # A simple presenter for the services and details of the Wellness System.
+  # This does not contain any logic for running checks and gathering details,
+  # simply because the details and results should be passed in.
+  #
+  # @author Matthew A. Johnston (warmwaffles)
+  class Report
+    # @param services [Hash]
+    # @param details [Hash]
+    def initialize(services={}, details={})
+      @services = services
+      @details = details
+    end
+
+    # @return [Hash]
+    def detailed
+      {
+        status: status,
+        services: @services,
+        details: @details
+      }
+    end
+
+    # @return [Hash]
+    def simple
+      {
+        status: status
+      }
+    end
+
+    # Returns the {#detailed} hash in json form
+    #
+    # @return [String]
+    def to_json(*)
+      detailed.to_json
+    end
+
+    # @return [String]
+    def status
+      healthy? ? 'HEALTHY' : 'UNHEALTHY'
+    end
+
+    # @return [Integer]
+    def status_code
+      healthy? ? 200 : 500
+    end
+
+    # @return [TrueClass,FalseClass]
+    def healthy?
+      @services.values.all? { |h| h[:status] == 'HEALTHY' }
+    end
+  end
+end

--- a/lib/wellness/services/base.rb
+++ b/lib/wellness/services/base.rb
@@ -2,7 +2,7 @@ module Wellness
   module Services
     # @author Matthew A. Johnston
     class Base
-      attr_reader :params
+      attr_reader :params, :result, :name
 
       # Load dependencies when the class is loaded. This makes putting requires
       # at the top of the file unnecessary. It plays nicely with the
@@ -12,51 +12,37 @@ module Wellness
       end
 
       # @param params [Hash]
-      def initialize(params={})
+      def initialize(name, params={})
+        @name = name
         @params = params
-        @health = false
-        @mutex = Mutex.new
-      end
-
-      # Flags the check as failed
-      # @return [FalseClass]
-      def failed_check
-        @mutex.synchronize do
-          @health = false
-        end
-      end
-
-      # Flags the check as passed
-      # @return [TrueClass]
-      def passed_check
-        @mutex.synchronize do
-          @health = true
-        end
+        @result = {}
       end
 
       # Returns true if the service is healthy, otherwise false
       # @return [TrueClass,FalseClass]
       def healthy?
-        @mutex.synchronize do
-          !!@health
-        end
+        @result.fetch(:status, 'UNHEALTHY') == 'HEALTHY'
       end
 
-      # @return [Hash]
+      def passed_check
+        warn('#passed_check has been deprecated')
+      end
+
+      def failed_check
+        warn('#failed_check has been deprecated')
+      end
+
+      # @return [Wellness::Services::Base]
       def call
-        @last_check = self.check
+        @result = self.check
+        self
       end
 
       # @return [Hash]
       def check
-        {}
-      end
-
-      # @return [Hash]
-      def last_check
-        @mutex.synchronize do
-          @last_check ||= {}
-        end
+        {
+          status: 'UNHEALTHY'
+        }
       end
     end
   end

--- a/lib/wellness/services/postgres_service.rb
+++ b/lib/wellness/services/postgres_service.rb
@@ -6,8 +6,9 @@ module Wellness
         require('pg')
       end
 
+      # @return [Hash]
       def check
-        case ping
+        case PG::Connection.ping(connection_options)
         when PG::Constants::PQPING_NO_ATTEMPT
           ping_failed('no attempt made to ping')
         when PG::Constants::PQPING_NO_RESPONSE
@@ -20,10 +21,6 @@ module Wellness
       end
 
       private
-
-      def ping
-        PG::Connection.ping(connection_options)
-      end
 
       # @return [Hash]
       def connection_options
@@ -39,7 +36,6 @@ module Wellness
       # @param message [String] the reason it failed
       # @return [Hash]
       def ping_failed(message)
-        failed_check
         {
           status: 'UNHEALTHY',
           details: {
@@ -50,7 +46,6 @@ module Wellness
 
       # @return [Hash]
       def ping_successful
-        passed_check
         {
           status: 'HEALTHY',
           details: {

--- a/lib/wellness/services/redis_service.rb
+++ b/lib/wellness/services/redis_service.rb
@@ -22,27 +22,35 @@ module Wellness
         require('redis')
       end
 
+      # @return [Hash]
       def check
         client = build_client
         details = client.info.select { |k, _| KEYS.include?(k) }
+        passed(details)
+      rescue Redis::BaseError => error
+        failed(error)
+      rescue Exception => error
+        failed(error)
+      end
 
-        passed_check
+      def build_client
+        Redis.new(self.params)
+      end
+
+      def passed(details)
         {
           status: 'HEALTHY',
           details: details
         }
-      rescue Redis::BaseError => error
-        failed_check
+      end
+
+      def failed(error)
         {
           status: 'UNHEALTHY',
           details: {
             error: error.message
           }
         }
-      end
-
-      def build_client
-        Redis.new(self.params)
       end
     end
   end

--- a/lib/wellness/services/sidekiq_service.rb
+++ b/lib/wellness/services/sidekiq_service.rb
@@ -9,14 +9,14 @@ module Wellness
         require 'sidekiq'
       end
 
+      # @return [Hash]
       def check
         sidekiq_stats = Sidekiq::Stats.new
         queue = Sidekiq::Queue.new
         redis = Redis.new(self.params.fetch(:redis))
         redis_stats = redis.info.select { |k, _| KEYS.include?(k) }
-        workers_size = redis.scard("workers").to_i
+        workers_size = redis.scard('workers').to_i
 
-        passed_check
         {
           status: 'HEALTHY',
           details: {
@@ -31,7 +31,6 @@ module Wellness
           }
         }
       rescue => error
-        failed_check
         {
           status: 'UNHEALTHY',
           details: {

--- a/lib/wellness/system.rb
+++ b/lib/wellness/system.rb
@@ -34,16 +34,16 @@ module Wellness
 
     def build_report
       @mutex.synchronize do
-        Wellness::Report.new(services, details)
+        Wellness::Report.new(services.map(&:call), details.map(&:call))
       end
     end
 
     def services
-      Hash[@services.map(&:build).map { |s| [s.name, s.check] }]
+      @services.map(&:build)
     end
 
     def details
-      Hash[@details.map(&:build).map { |d| [d.name, d.call] }]
+      @details.map(&:build)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'simplecov'
 SimpleCov.start do
+  add_filter('/spec')
   add_group('Services', 'wellness/services')
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,7 @@ SimpleCov.start do
   add_group('Services', 'wellness/services')
 end
 
+Dir[Dir.pwd.concat('/spec/support/**/*.rb')].each { |f| require f }
+
 require 'rspec'
 require 'wellness'

--- a/spec/support/services_support.rb
+++ b/spec/support/services_support.rb
@@ -1,0 +1,17 @@
+class UnhealthyService < Wellness::Services::Base
+  def check
+    { status: 'UNHEALTHY' }
+  end
+end
+
+class HealthyService < Wellness::Services::Base
+  def check
+    { status: 'HEALTHY' }
+  end
+end
+
+class MockedDetail < Wellness::Detail
+  def check
+    { 'data' => 'here' }
+  end
+end

--- a/spec/wellness/detail_spec.rb
+++ b/spec/wellness/detail_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Wellness::Detail do
+  let(:detail) { described_class.new('test_detail') }
+
+  describe '#name' do
+    subject { detail.name }
+    it 'returns "test_detail"' do
+      expect(subject).to eq('test_detail')
+    end
+  end
+
+  describe '#call' do
+    subject { detail.call }
+    it 'returns an empty hash' do
+      expect(subject).to be_empty
+    end
+  end
+end

--- a/spec/wellness/detail_spec.rb
+++ b/spec/wellness/detail_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Wellness::Detail do
-  let(:detail) { described_class.new('test_detail') }
+  let(:detail) { MockedDetail.new('test_detail') }
 
   describe '#name' do
     subject { detail.name }
@@ -12,8 +12,15 @@ describe Wellness::Detail do
 
   describe '#call' do
     subject { detail.call }
-    it 'returns an empty hash' do
-      expect(subject).to be_empty
+    it 'sets the result' do
+      expect { subject }.to change(detail, :result)
+    end
+  end
+
+  describe '#check' do
+    subject { detail.check }
+    it 'returns a hash' do
+      expect(subject).to be_a(Hash)
     end
   end
 end

--- a/spec/wellness/report_spec.rb
+++ b/spec/wellness/report_spec.rb
@@ -59,22 +59,25 @@ describe Wellness::Report do
   describe '#healthy?' do
     subject { report.healthy? }
     context 'when all of the report are healthy' do
-      let(:services) { { 'foo' => { status: 'HEALTHY' }, 'bar' => { status: 'HEALTHY' } } }
-      let(:report) { described_class.new(services, {}) }
+      let(:services) { [HealthyService.new('service-a'), HealthyService.new('service-b')] }
+      let(:report) { described_class.new(services, []) }
+      before { services.collect(&:call) }
       it 'returns true' do
         expect(subject).to eq(true)
       end
     end
     context 'when one of the reports are not healthy' do
-      let(:services) { { 'foo' => { status: 'HEALTHY' }, 'bar' => { status: 'UNHEALTHY' } } }
-      let(:report) { described_class.new(services, {}) }
+      let(:services) { [HealthyService.new('service-a'), UnhealthyService.new('service-b')] }
+      let(:report) { described_class.new(services, []) }
+      before { services.collect(&:call) }
       it 'returns false' do
         expect(subject).to eq(false)
       end
     end
     context 'when all of the reports are not healthy' do
-      let(:services) { { 'foo' => { status: 'UNHEALTHY' }, 'bar' => { status: 'UNHEALTHY' } } }
-      let(:report) { described_class.new(services, {}) }
+      let(:services) { [UnhealthyService.new('service-a'), UnhealthyService.new('service-b')] }
+      let(:report) { described_class.new(services, []) }
+      before { services.collect(&:call) }
       it 'returns false' do
         expect(subject).to eq(false)
       end

--- a/spec/wellness/report_spec.rb
+++ b/spec/wellness/report_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe Wellness::Report do
+  let(:report) { described_class.new({}, {}) }
+
+  describe '#to_json' do
+    subject { report.to_json }
+    it 'returns a json string' do
+      expect(JSON.parse(subject)).to be_a(Hash)
+    end
+  end
+
+  describe '#detailed' do
+    subject { report.detailed }
+    it 'returns a hash' do
+      expect(subject).to be_a(Hash)
+    end
+  end
+
+  describe '#simple' do
+    subject { report.simple }
+    it 'returns a hash' do
+      expect(subject).to be_a(Hash)
+    end
+  end
+
+  describe '#status' do
+    subject { report.status }
+    context 'when the report is healthy' do
+      before { report.stub(:healthy? => true) }
+      it 'returns HEALTHY' do
+        expect(subject).to eq('HEALTHY')
+      end
+    end
+    context 'when the report is not healthy' do
+      before { report.stub(:healthy? => false) }
+      it 'returns UNHEALTHY' do
+        expect(subject).to eq('UNHEALTHY')
+      end
+    end
+  end
+
+  describe '#status_code' do
+    subject { report.status_code }
+    context 'when the report is healthy' do
+      before { report.stub(:healthy? => true) }
+      it 'returns 200' do
+        expect(subject).to eq(200)
+      end
+    end
+    context 'when the report is not healthy' do
+      before { report.stub(:healthy? => false) }
+      it 'returns 500' do
+        expect(subject).to eq(500)
+      end
+    end
+  end
+
+  describe '#healthy?' do
+    subject { report.healthy? }
+    context 'when all of the report are healthy' do
+      let(:services) { { 'foo' => { status: 'HEALTHY' }, 'bar' => { status: 'HEALTHY' } } }
+      let(:report) { described_class.new(services, {}) }
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+    context 'when one of the reports are not healthy' do
+      let(:services) { { 'foo' => { status: 'HEALTHY' }, 'bar' => { status: 'UNHEALTHY' } } }
+      let(:report) { described_class.new(services, {}) }
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+    context 'when all of the reports are not healthy' do
+      let(:services) { { 'foo' => { status: 'UNHEALTHY' }, 'bar' => { status: 'UNHEALTHY' } } }
+      let(:report) { described_class.new(services, {}) }
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+  end
+end
+

--- a/spec/wellness/services/base_spec.rb
+++ b/spec/wellness/services/base_spec.rb
@@ -1,40 +1,51 @@
 require 'spec_helper'
 
 describe Wellness::Services::Base do
-  let(:params) { { test: 'data' } }
+  let(:params) { { foo: 'bar' } }
   let(:service) { described_class.new(params) }
-  describe '#failed_check' do
-    before { service.passed_check }
-    subject { service.failed_check }
-    it 'returns false' do
-      expect(subject).to eq(false)
+
+  describe '#healthy?' do
+    subject { service.healthy? }
+    context 'when the status key is missing' do
+      before { service.result.delete(:status) }
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
     end
-    it 'flags the service as unhealthy' do
-      expect { subject }.to change(service, :healthy?).from(true).to(false)
+    context 'when the status is UNHEALTHY' do
+      before { service.result[:status] = 'UNHEALTHY' }
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+    context 'when the status is HEALTHY' do
+      before { service.result[:status] = 'HEALTHY' }
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
     end
   end
 
-  describe '#passed_check' do
-    subject { service.passed_check }
-    it 'returns true' do
-      expect(subject).to eq(true)
-    end
-    it 'flags the service as healthy' do
-      expect { subject }.to change(service, :healthy?).from(false).to(true)
-    end
-  end
+  describe '#call' do
+    let(:result) { {status: 'HEALTHY'} }
+    subject { service.call }
 
-  describe '#params' do
-    subject { service.params }
-    it 'returns the params that it was constructed with' do
-      expect(subject).to eq(params)
+    before { service.stub(check: result) }
+
+    it 'receives the #call method' do
+      subject
+      expect(service).to have_received(:check).once
+    end
+
+    it 'sets the result' do
+      expect { subject }.to change { service.result }.to(result)
     end
   end
 
   describe '#check' do
     subject { service.check }
-    it 'returns an empty hash' do
-      expect(subject).to eq({})
+    it 'returns a status of UNHEALTHY' do
+      expect(subject).to include(status: 'UNHEALTHY')
     end
   end
 end

--- a/spec/wellness/services/redis_service_spec.rb
+++ b/spec/wellness/services/redis_service_spec.rb
@@ -27,21 +27,5 @@ describe Wellness::Services::RedisService do
       'keyspace_misses' => '0'
     }
   }
-  describe '#check' do
-    subject { service.check }
-    context 'when redis can\'t connect' do
-      it 'fails the health check' do
-        expect(subject).to include(status: 'UNHEALTHY')
-      end
-    end
-    context 'when redis returns the its details' do
-      let(:client) { double('Redis', info: redis_info) }
-      before do
-        service.stub(build_client: client)
-      end
-      it 'passes the health check' do
-        expect(subject).to include(status: 'HEALTHY')
-      end
-    end
-  end
+  pending
 end

--- a/spec/wellness/system_spec.rb
+++ b/spec/wellness/system_spec.rb
@@ -3,24 +3,6 @@ require 'spec_helper'
 describe Wellness::System do
   let(:system) { described_class.new('test_system') }
 
-  class UnhealthyService < Wellness::Services::Base
-    def check
-      { status: 'UNHEALTHY' }
-    end
-  end
-
-  class HealthyService < Wellness::Services::Base
-    def check
-      { status: 'HEALTHY' }
-    end
-  end
-
-  class MockedDetail < Wellness::Detail
-    def call
-      { 'data' => 'here' }
-    end
-  end
-
   describe '#use' do
     context 'when a Wellness::Services::Base is provided' do
       subject { system.use(HealthyService, 'test_service') }


### PR DESCRIPTION
There are some major fundemental changes with the library. For instance, now we will be treating the `Wellness::System` similar to how we treat `Rack`.

``` ruby
  system = Wellness::System.new('some_system')
  system.use(Wellness::Services::RedisService, { ... })
  system.use(Wellness::Services::PostgresService, { ... })

  config.middleware.insert_before(
    '::ActiveRecord::QueryCache',
    'Wellness::Middleware',
    system
  )
```

The `Wellness::Services::Base` hasn't changed too much, `#check` is still working just find, `#passed_check` is deprecated, `#failed_check` is deprecated. Currently they will just `#warn` when it is used.
