### PR TITLE
Change redis close connection method

### DIFF
--- a/lib/wellness/services/redis_service.rb
+++ b/lib/wellness/services/redis_service.rb
@@ -28,7 +28,7 @@ module Wellness
       def call
         client  = Redis.new(@params)
         details = client.info.select { |k, _| KEYS.include?(k) }
-        client.disconnect
+        client.quit
 
         {
           'status' => 'HEALTHY',


### PR DESCRIPTION
`disconnect` was not working properly and was making my wellness believe the service was unhealthy when in reality it was. Using the `quit` method yields the expected behavior.
